### PR TITLE
Fixed windows detection by excluding "Darwin" which is Mac OSX identifier

### DIFF
--- a/src/ScaffoldCommand.php
+++ b/src/ScaffoldCommand.php
@@ -349,7 +349,7 @@ class ScaffoldCommand extends Command
 
     protected function configure()
     {
-        $homePath = stripos(PHP_OS, 'win') !== false
+        $homePath = (stripos(PHP_OS, 'win') !== false && stripos(PHP_OS, 'darwin') === false)
             ? $_SERVER['HOMEDRIVE'] . $_SERVER['HOME_PATH']
             : getenv('HOME');
 


### PR DESCRIPTION
Mac identifies as "Darwin" so on Mac it incorrectly goes down the windows path which then tosses out some exceptions. Fixes #2 
