### PR TITLE
added autoload bootstrap to phpunit config

### DIFF
--- a/templates/phpunit.xml.twig
+++ b/templates/phpunit.xml.twig
@@ -6,6 +6,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="true"
+         bootstrap="vendor/autoload.php"
 >
     <testsuites>
         <testsuite name="{{composer_name}} test suite">


### PR DESCRIPTION
A minor change to add support for running 'phpunit' from the project root (if you already have it installed) and have it load in your autoloader.php, rather than having to use vendor/bin/phpunit