### PR TITLE
#7 Fixed Travis CI URL generation

### DIFF
--- a/src/ScaffoldCommand.php
+++ b/src/ScaffoldCommand.php
@@ -136,7 +136,9 @@ class ScaffoldCommand extends Command
 
         $defaultSettings['repo_url'] = $defaultSettings['base_repo_url'] . $this->parameters['composer_name'];
         $this->askForSetting($defaultSettings, 'repo_url', 'Repo URL');
-        $this->parameters['repo_name'] = substr(strrchr($this->parameters['repo_url'], '/'), 1);
+        $repoParts = explode('/', $this->parameters['repo_url']);
+        $this->parameters['repo_name'] = array_pop($repoParts);
+        $this->parameters['repo_owner'] = array_pop($repoParts);
 
         $this->askForSetting($defaultSettings, 'issues_url', 'Issues URL');
 

--- a/templates/README.md.twig
+++ b/templates/README.md.twig
@@ -2,7 +2,7 @@
 
 [Phergie](http://github.com/phergie/phergie-irc-bot-react/) plugin for {{purpose}}.
 
-[![Build Status](https://secure.travis-ci.org/{{composer_name}}.png?branch=master)](http://travis-ci.org/{{composer_name}})
+[![Build Status](https://secure.travis-ci.org/{{repo_owner}}/{{repo_name}}.png?branch=master)](http://travis-ci.org/{{repo_owner}}/{{repo_name}})
 
 ## Install
 


### PR DESCRIPTION
Created 'repo_owner' param (derived from 'repo_url') and used it (along with 'repo_name') to build urls for Travis CI.