### PR TITLE
Various improvements/updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/*
+.idea/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 vendor/*
-.idea/*

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Author URL (default http://phergie.org):
 License name (default New BSD License):
 License URL (default http://phergie.org/license):
 Composer license value (default BSD-2-Clause):
-Copyright years (default 2014): 2008-2014
+Copyright years (default 2015): 2008-2015
 composer.json name attribute (default phergie/phergie-irc-plugin-react-test):
 Repo URL (default https://github.com/phergie/phergie-irc-plugin-react-test):
 Issues URL: https://github.com/phergie/phergie-irc-plugin-react-test/issues
@@ -84,7 +84,7 @@ Here's an example configuration file:
 author_email=me@matthewturland.com
 author_name=Matthew Turland
 author_url=http://matthewturland.com
-copyright_years=2008-2014
+copyright_years=2008-2015
 license_name=MIT License
 license_url=http://opensource.org/licenses/MIT
 license_value=MIT

--- a/bin/phergie-scaffold
+++ b/bin/phergie-scaffold
@@ -4,7 +4,7 @@
  * Phergie (http://phergie.org)
  *
  * @link http://github.com/phergie/phergie-irc-plugin-react-scaffold for the canonical source repository
- * @copyright Copyright (c) 2008-2014 Phergie Development Team (http://phergie.org)
+ * @copyright Copyright (c) 2008-2015 Phergie Development Team (http://phergie.org)
  * @license http://phergie.org/license New BSD License
  * @package Phergie\Irc\Bot\React
  */

--- a/src/Application.php
+++ b/src/Application.php
@@ -3,7 +3,7 @@
  * Phergie (http://phergie.org)
  *
  * @link https://github.com/phergie/phergie-irc-plugin-react-scaffold for the canonical source repository
- * @copyright Copyright (c) 2008-2014 Phergie Development Team (http://phergie.org)
+ * @copyright Copyright (c) 2008-2015 Phergie Development Team (http://phergie.org)
  * @license http://phergie.org/license New BSD License
  * @package Phergie\Irc\Plugin\React\Scaffold
  */

--- a/src/ScaffoldCommand.php
+++ b/src/ScaffoldCommand.php
@@ -3,7 +3,7 @@
  * Phergie (http://phergie.org)
  *
  * @link https://github.com/phergie/phergie-irc-plugin-react-scaffold for the canonical source repository
- * @copyright Copyright (c) 2008-2014 Phergie Development Team (http://phergie.org)
+ * @copyright Copyright (c) 2008-2015 Phergie Development Team (http://phergie.org)
  * @license http://phergie.org/license New BSD License
  * @package Phergie\Irc\Plugin\React\Scaffold
  */

--- a/src/ScaffoldCommand.php
+++ b/src/ScaffoldCommand.php
@@ -140,6 +140,7 @@ class ScaffoldCommand extends Command
         $this->parameters['repo_name'] = array_pop($repoParts);
         $this->parameters['repo_owner'] = array_pop($repoParts);
 
+        $defaultSettings['issues_url'] = $defaultSettings['repo_url'] . '/issues';
         $this->askForSetting($defaultSettings, 'issues_url', 'Issues URL');
 
         $defaultSettings['package_namespace'] = $defaultSettings['base_namespace'] . ucfirst($this->parameters['short_name']);

--- a/templates/.travis.yml.twig
+++ b/templates/.travis.yml.twig
@@ -11,8 +11,8 @@ matrix:
     - php: hhvm
 
 before_script:
-  - composer self-update
-  - composer install
+  - travis_retry composer self-update
+  - travis_retry composer install
 
 script:
   - ./vendor/bin/phpunit --coverage-text

--- a/templates/composer.json.twig
+++ b/templates/composer.json.twig
@@ -17,7 +17,6 @@
         "issues": "{{issues_url}}",
         "source": "{{repo_url}}"
     },
-    "minimum-stability": "dev",
     "require": {
         "phergie/phergie-irc-bot-react": "~1"{% if command_plugin %},
         "phergie/phergie-irc-plugin-react-command": "~1.0"
@@ -25,7 +24,7 @@
 
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "4.5.*",
         "phake/phake": "2.0.0-beta2"
     },
 {% if command_plugin %}

--- a/templates/composer.json.twig
+++ b/templates/composer.json.twig
@@ -3,6 +3,14 @@
     "description": "Phergie plugin for {{purpose}}",
     "keywords": [ "phergie", "irc", "bot", "plugin" ],
     "license": "{{license_value}}",
+    "authors": [
+        {
+            "name": "{{author_name}}",
+            "email": "{{author_email}}",
+            "homepage": "{{author_url}}",
+            "role": "Developer"
+        }
+    ],
     "support": {
         "email": "{{author_email}}",
         "irc": "irc://irc.freenode.net/phergie",
@@ -33,6 +41,11 @@
     "autoload-dev": {
         "psr-4": {
             "{{composer_tests_namespace}}\\": "tests"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
         }
     }
 }


### PR DESCRIPTION
2943331 - prompts travis to try 3 times to update/run composer before quitting, minimizing chances of build failures due to network issues (http://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/)

f4daa9e - added composer.json authors section using existing captured info (https://getcomposer.org/doc/04-schema.md#authors) - also added default 1.0-dev branch alias to allow including development versions without having to set minimum-stability to dev and include dev versions of everything (https://getcomposer.org/doc/articles/aliases.md)

26ca19e - added default issues url to cli setup (currently defaults to blank, which if left breaks composer update due to invalid url)

fc45fad - removed minimum stability dev as bot is now tagged - otherwise raises likelihood of plugin being used with untested packages when used as plugin (ie, non root context) as composer stability defaults to stable unless explicitly stated otherwise. Also bumped phpunit version to 4.5 (tested with my own plugins with no issues)