### PR TITLE
Updated scaffold template and app to PHP 5.4 syntax.

### DIFF
--- a/bin/phergie-scaffold
+++ b/bin/phergie-scaffold
@@ -13,11 +13,11 @@ if (!isset($argv)) {
     trigger_error('Please enable register_argc_argv in your PHP configuration', E_USER_ERROR);
 }
 
-set_include_path(implode(PATH_SEPARATOR, array(
+set_include_path(implode(PATH_SEPARATOR, [
     get_include_path(),
     __DIR__ . '/../vendor', // for bin/ when invoked from git repo clone
     __DIR__ . '/../../..',  // for vendor/bin when installed via Composer
-)));
+]));
 require 'autoload.php';
 
 use Phergie\Irc\Plugin\React\Scaffold\Application;

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     },
     "minimum-stability": "dev",
     "require": {
+        "php": ">=5.4.2",
         "symfony/console": "~2.4",
         "symfony/process": "~2.4",
         "twig/twig": "~1.15"

--- a/src/ScaffoldCommand.php
+++ b/src/ScaffoldCommand.php
@@ -36,7 +36,7 @@ class ScaffoldCommand extends Command
      *
      * @var array
      */
-    protected $parameters = array();
+    protected $parameters = [];
 
     /**
      * Path to directory containing template files
@@ -71,7 +71,7 @@ class ScaffoldCommand extends Command
     {
         parent::__construct();
         $this->templatePath = __DIR__ . '/../templates';
-        $this->defaultSettings = array(
+        $this->defaultSettings = [
             'base_composer_name' => 'phergie/phergie-irc-plugin-react-',
             'base_namespace' => 'Phergie\\Irc\\Plugin\\React\\',
             'base_tests_namespace' => 'Phergie\\Irc\\Tests\\Plugin\\React\\',
@@ -89,7 +89,7 @@ class ScaffoldCommand extends Command
             'license_name' => 'New BSD License',
             'license_url' => 'http://phergie.org/license',
             'license_value' => 'BSD-2-Clause',
-        );
+        ];
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -192,7 +192,7 @@ class ScaffoldCommand extends Command
 
     protected function getDefaultSettingsFromFile()
     {
-        $defaultSettings = array();
+        $defaultSettings = [];
         $defaultsFile = $this->input->getArgument('defaults-file');
 
         if (file_exists($defaultsFile)) {
@@ -215,11 +215,11 @@ class ScaffoldCommand extends Command
 
     protected function createDirectories()
     {
-        $dirs = array(
+        $dirs = [
             '',
             '/src',
             '/tests',
-        );
+        ];
 
         $repo = $this->parameters['repo_name'];
         foreach ($dirs as $dir) {
@@ -374,7 +374,7 @@ class ScaffoldCommand extends Command
     protected function getTwig()
     {
         $loader = new \Twig_Loader_Filesystem($this->templatePath);
-        $twig = new \Twig_Environment($loader, array('autoescape' => false));
+        $twig = new \Twig_Environment($loader, ['autoescape' => false]);
         return $twig;
     }
 
@@ -385,6 +385,7 @@ class ScaffoldCommand extends Command
      * @param string $path File path to receive the generated result
      * @param string $description Description of the file being generated
      * @param OutputInterface $output
+     * @return boolean
      */
     protected function generateFile($template, $path, $description)
     {

--- a/templates/.travis.yml.twig
+++ b/templates/.travis.yml.twig
@@ -4,10 +4,12 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7
   - hhvm
 
 matrix:
   allow_failures:
+    - php: 7
     - php: hhvm
 
 before_script:

--- a/templates/Plugin.php.twig
+++ b/templates/Plugin.php.twig
@@ -31,7 +31,7 @@ class Plugin extends AbstractPlugin
      *
      * @param array $config
      */
-    public function __construct(array $config = array())
+    public function __construct(array $config = [])
     {
 
     }
@@ -43,9 +43,9 @@ class Plugin extends AbstractPlugin
      */
     public function getSubscribedEvents()
     {
-        return array(
+        return [
             '{% if command_plugin %}command{% else %}irc{% endif %}.' => '{{handler_method}}',
-        );
+        ];
     }
 
     /**

--- a/templates/README.md.twig
+++ b/templates/README.md.twig
@@ -22,11 +22,16 @@ See Phergie documentation for more information on
 ## Configuration
 
 ```php
-new \{{package_namespace}}\Plugin(array(
+return [
+    'plugins' => [
+        // configuration
+        new \{{package_namespace}}\Plugin([
 
 
 
-))
+        ])
+    ]
+];
 ```
 
 ## Tests


### PR DESCRIPTION
* Replaced long array syntax with short array syntax (in scaffold app and templates).
* Explicitly set min PHP version of scaffold app to 5.4.2 (prior to this change, the scaffold app would install and run but fail during composer install of the new plug-in).
* Added PHP 7 to Travis CI config template.
* Updated "Configuration" section of README template to a more complete snippet.