### PR TITLE
Change composer to be the require command and add commands section

### DIFF
--- a/templates/README.md.twig
+++ b/templates/README.md.twig
@@ -8,17 +8,18 @@
 
 The recommended method of installation is [through composer](http://getcomposer.org).
 
-```JSON
-{
-    "require": {
-        "{{composer_name}}": "dev-master"
-    }
-}
-```
+`php composer.phar require {{composer_name}}`
 
 See Phergie documentation for more information on
 [installing and enabling plugins](https://github.com/phergie/phergie-irc-bot-react/wiki/Usage#plugins).
 
+{% if command_plugin %}
+## Provided Commands
+
+| Command    | Parameters        | Description           |
+|:----------:|-------------------|-----------------------|
+| {commmand} | [param1] [param2] | {description}         |
+{% endif %}
 ## Configuration
 
 ```php


### PR DESCRIPTION
Using the composer require command is the best practices way to add a dependency to your project.

The commands section should hopefully help prompt more plugin authors to document their commands as most at the moment you have to guess or look at the source code for details.